### PR TITLE
Use multiple -o options in botnet commands

### DIFF
--- a/abusehelper/tools/botnet/commands.py
+++ b/abusehelper/tools/botnet/commands.py
@@ -45,7 +45,7 @@ def name_for_signal(signum, default=None):
 
 
 def ps():
-    process = popen("ps", "-wwAo", "pid=,ppid=,command=")
+    process = popen("ps", "-wwA", "-o", "pid=", "-o", "ppid=", "-o", "command=")
     stdout, stderr = process.communicate()
     if process.returncode != 0:
         sys.stderr.write(stderr)


### PR DESCRIPTION
This ensures that the botnet script is FreeBSD compatible.
Tested on FreeBSD 10.3, OpenBSD 5.9, OSX 10.11.6, Ubuntu 14.04 and Debian 8.
