### PR TITLE
Add log_level parameter to bots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Features
+ * Add log level option for bots ([#80](https://github.com/abusesa/abusehelper/pull/80)).
+
 ### Fixes
 
  * Remove duplicate parsing code from ```abusehelper.bots.openbl.openblbot ``` ([adc6eb1] (https://github.com/abusesa/abusehelper/commit/adc6eb1868f15347384423c066b6e73afb2b05cc))

--- a/abusehelper/__init__.py
+++ b/abusehelper/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "5.0.1.dev1"
+__version__ = "5.0.1.dev2"

--- a/abusehelper/core/bot.py
+++ b/abusehelper/core/bot.py
@@ -134,6 +134,10 @@ class Bot(object):
     log_file = Param(
         "write logs to the given path (default: log to stdout)",
         default=None)
+    log_level = IntParam(
+        "logging level (default: logging.INFO)",
+        default=logging.INFO
+    )
 
     @classmethod
     def params(cls):
@@ -280,18 +284,18 @@ class Bot(object):
             name = keys.keys()[0]
             raise TypeError("got an unexpected keyword argument " + repr(name))
 
-        self.log = self.create_logger()
+        self.log = self.create_logger(self.log_level)
 
-    def create_logger(self):
+    def create_logger(self, log_level=logging.INFO):
         logger = logging.getLogger(self.bot_name)
-        logger.setLevel(logging.INFO)
+        logger.setLevel(log_level)
 
         if self.log_file is None:
             handler = logging.StreamHandler()
         else:
             handler = logging.handlers.WatchedFileHandler(self.log_file)
         handler.setFormatter(LineFormatter())
-        handler.setLevel(logging.INFO)
+        handler.setLevel(log_level)
 
         logger.addHandler(handler)
         return log.EventLogger(logger)


### PR DESCRIPTION
Often times it makes sense to be able to set different logging level for particular bot. This is especially true for development, testing and debugging of bots.
