### PR TITLE
Improve robustness and add more human readable error messages

### DIFF
--- a/abusehelper/core/bot.py
+++ b/abusehelper/core/bot.py
@@ -18,7 +18,7 @@ import idiokit
 from idiokit.xmpp import connect
 from idiokit.xmpp.core import XMPPError
 from idiokit.socket import SocketError
-from idiokit.dns import DNSTimeout
+from idiokit.dns import DNSTimeout, DNSError
 
 from . import log, events, taskfarm, utils, services
 from .. import __version__
@@ -395,7 +395,7 @@ class ServiceBot(XMPPBot):
         self.log.info("Starting service {0!r} version {1}".format(self.bot_name, __version__))
         try:
             self.xmpp = yield self.xmpp_connect()
-        except (SocketError, XMPPError, DNSTimeout) as error:
+        except (SocketError, XMPPError, DNSTimeout, DNSError) as error:
             self.log.critical("Failed to connect to XMPP service ({0!r}): {1}".format(
                               self.xmpp_jid, error))
             return
@@ -422,6 +422,9 @@ class ServiceBot(XMPPBot):
         self.log.info("Offering service " + repr(self.bot_name))
         try:
             yield self.lobby.offer(self.bot_name, service)
+        except (SocketError, XMPPError) as error:
+            self.log.critical("Lost lobby: {0}".format(str(error)))
+            raise services.Stop()
         finally:
             self.log.info("Retired service " + repr(self.bot_name))
 


### PR DESCRIPTION
Currently most of temporary network errors are handled by crashing the bot and letting the startup to restart bot. This means that state can be lost because of temporary network hiccup. It also makes it harder to see what was the actual problem, because log is filled with tracebacks.

This pull request changes core components to raise services.Stop in case of network error, which allows bot to shutdown gracefully. Error messages are also improved significantly.

Examples:

Wrong authentication credentials:

`2017-01-18 13:25:12Z roomgraph[1551] CRITICAL Failed to connect to XMPP service ('example@abusesa.com'): authentication failed`

Badly configured or broken network:

`2017-01-18 13:24:56Z roomgraph[1541] CRITICAL Failed to connect to XMPP service ('example@abusesa.com'): no DNS servers specified`